### PR TITLE
fix: url typo

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -45,7 +45,7 @@ The installation script automatically:
 If you prefer to configure manually, set these environment variables:
 
 ```bash
-export ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic/
+export ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic/
 export ANTHROPIC_API_KEY=your_moonshot_api_key_here
 ```
 


### PR DESCRIPTION
Based on the documentation and testing, the correct base url is https://api.moonshot.ai/anthropic

Source: https://platform.moonshot.ai/docs/guide/agent-support.en-US#configure-anthropic-api