### PR TITLE
Add debugging section for 401 and 429 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,33 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/LLM-Red-Team/kimi-cc/ref
 ```shell
 claude
 ```
+
+## 常见问题与调试
+
+### 401 错误（认证失败）
+
+如果遇到 401 错误，有两种解决方法，任选其一：
+
+**方法1：检查环境变量**
+
+运行脚本后，在 `~/.bashrc`（如果使用 zsh 则在 `~/.zshrc`）中检查以下配置是否正确：
+- `ANTHROPIC_AUTH_TOKEN` 是否设置正确
+- `ANTHROPIC_BASE_URL` 是否设置正确
+
+**方法2：手动配置**
+
+手动在 `~/.claude/settings.json` 中设置：
+```json
+{
+  "ANTHROPIC_AUTH_TOKEN": "你的API密钥",
+  "ANTHROPIC_BASE_URL": "根据API生成来源设置"
+}
+```
+
+**域名配置说明：**
+- 如果你的 API 是在 `platform.moonshot.cn` 下生成的，确保 `ANTHROPIC_BASE_URL` 设置为 `api.moonshot.cn/anthropic`
+- 否则设置为 `api.moonshot.ai/anthropic`
+
+### 429 错误（请求频率限制）
+
+在官方平台充值最低档即提升并发量即可解决429问题。

--- a/README_EN.md
+++ b/README_EN.md
@@ -49,6 +49,36 @@ export ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic/
 export ANTHROPIC_API_KEY=your_moonshot_api_key_here
 ```
 
+## Troubleshooting
+
+### 401 Error (Authentication Failed)
+
+If you encounter a 401 error, try one of these two solutions:
+
+**Method 1: Check Environment Variables**
+
+After running the script, check the following configurations in your `~/.bashrc` (or `~/.zshrc` if using zsh):
+- Ensure `ANTHROPIC_AUTH_TOKEN` is set correctly
+- Ensure `ANTHROPIC_BASE_URL` is set correctly
+
+**Method 2: Manual Configuration**
+
+Manually set the configuration in `~/.claude/settings.json`:
+```json
+{
+  "ANTHROPIC_AUTH_TOKEN": "your-api-key",
+  "ANTHROPIC_BASE_URL": "set-according-to-api-source"
+}
+```
+
+**Domain Configuration:**
+- If your API was generated under `platform.moonshot.cn`, ensure `ANTHROPIC_BASE_URL` is set to `api.moonshot.cn/anthropic`
+- Otherwise, set it to `api.moonshot.ai/anthropic`
+
+### 429 Error (Rate Limiting)
+
+To resolve 429 errors, make a minimum recharge on the official platform to increase concurrent request limits.
+
 ## Support
 
 For issues or questions, please visit the [Kimi Open Platform](https://platform.moonshot.cn/) or check the original Claude Code documentation. 


### PR DESCRIPTION
## Summary
  Added comprehensive debugging information to help users resolve common authentication and rate limiting issues.

  ## Changes Made
  - **README.md (中文)**: Added "常见问题与调试" section with 401/429 error solutions
  - **README_EN.md (English)**: Added "Troubleshooting" section with 401/429 error solutions

  ## Issues Addressed
  - 401 authentication errors with API setup
  - 429 rate limiting errors
  - Confusion about correct API endpoint configuration

  ## Solutions Provided
  - Two methods for 401 errors: environment check vs manual config
  - Domain configuration guidance for different API sources
  - 429 resolution:充值最低档提升并发量 / make minimum recharge to increase limits